### PR TITLE
fix: [satellite] don't use --content-view-id

### DIFF
--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -154,7 +154,7 @@ hammer content-view add-repository --name '{{ cv.name }}' --product '{{ repo.pro
 
 CREATE_ACTIVATION_KEYS="
 {% for ak in satellite.activation_keys if ak.name -%}
-hammer activation-key create --name '{{ ak.name }}' --content-view '{{ ak.cv|default('Default Organization View') }}' --lifecycle-environment '{{ ak.env|default('Library') }}' {{ '--max-hosts %s' % ak.max if ak.max is defined and ak.max }} {{ _desc_opt(ak) }} {{ '--content-view-id %s' % ak.content_view_id|default('1') }}
+hammer activation-key create --name '{{ ak.name }}' --content-view '{{ ak.cv|default('Default Organization View') }}' --lifecycle-environment '{{ ak.env|default('Library') }}' {{ '--max-hosts %s' % ak.max if ak.max is defined and ak.max }} {{ _desc_opt(ak) }}
 {% endfor -%}
 "
 


### PR DESCRIPTION
An id for a content view is given at run-time.  Such a value should
not be given at build-time, time expanding templates. Instead,
--content-view should be used.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>