### PR TITLE
enhancement: [satellite] verify the existence of domain component in FQDN

### DIFF
--- a/autoinstall.d/data/satellite/6/checks.d/10_30_hostname.sh
+++ b/autoinstall.d/data/satellite/6/checks.d/10_30_hostname.sh
@@ -14,4 +14,7 @@ hostname=${_CHECK_FQDN:-$(hostname -f)}
   exit 1
 }
 
+[[ ${hostname} =~ .+[.].+ ]] || {
+  echo "Error: FQDN is not set (no domain componet is foun in 'hostname -f' output" >&2
+}
 # vim:sw=2:ts=2:et:


### PR DESCRIPTION
In my project, hostname -f just returns a hostname because of a setting mistake.
