### PR TITLE
fix: [satellite] build correct ORG_LABEL from ORG_NAME

### DIFF
--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -80,7 +80,7 @@ SATELLITE_INSTALLER_OPTIONS="
 "
 
 ORG_NAME="{{ satellite.organization|default('Default Organization') }}"
-ORG_LABEL="${ORG_NAME/ /_}"
+ORG_LABEL="${ORG_NAME// /_}"
 LOC_NAME="Default Location"
 
 ORG_ID_FILE=${HOME}/.hammer/organization_id.txt


### PR DESCRIPTION
config.sh makes ORG_LABEL from ORG_NAME by replacing the first white
space with an underscore. This is not enough. All white spaces in
ORG_NAME must be replaced with underscores for making acceptable
ORG_LABEL.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>