### PR TITLE
enhance: [satellite] allow to specify a contraction number when assigning a subscription to an activation key

### DIFF
--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -167,13 +167,16 @@ hammer activation-key add-host-collection --name '{{ ak.name }}' --host-collecti
 ADD_SUBSCRIPTION_TO_ACTIVATION_KEYS='
 {% for ak in satellite.activation_keys if ak.name and
                                           (ak.subscription is defined and ak.subscription) or
-                                          (ak.subscriptions is defined and ak.subscriptions) -%}
+                                          (ak.subscriptions is defined and ak.subscriptions) or
+                                          (ak.subscription_contract is defined and ak.subscription_contract) -%}
 {%     if ak.subscriptions -%}
 {%         for sub in ak.subscriptions -%}
 sub_id=$(hammer --csv subscription list | sed -nr "s/.+,([^,]+),{{ sub }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
 {%         endfor -%}
-{%     else -%}
+{%     elif ak.subscription -%}
 sub_id=$(hammer --csv subscription list | sed -nr "s/.+,([^,]+),{{ ak.subscription }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
+{%     else -%}
+sub_id=$(hammer --csv subscription list | sed -nr "s/^[^,]+,([^,]+),.+,{{ ak.subscription_contract }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
 {%     endif -%}
 {% endfor -%}
 '


### PR DESCRIPTION
Surprisingly, I have to deal with 3 subscriptions having the same name in a manifest.
Only the way to distinguish is referring their contraction numbers.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>