### PR TITLE
enhance: [satellite] allow to use whitespaces in the name of organization (like "Red Hat")

### DIFF
--- a/autoinstall.d/data/satellite/6/10_install.sh
+++ b/autoinstall.d/data/satellite/6/10_install.sh
@@ -92,7 +92,7 @@ test -f ${f} || (
 test -d ${LOGDIR:?} || mkdir -p ${LOGDIR}
 satellite-installer --scenario satellite --help
 satellite-installer --scenario satellite \
-  ${SATELLITE_INSTALLER_OPTIONS:?} | \
+  "${SATELLITE_INSTALLER_OPTIONS[@]:?}" | \
 		tee 2>&1 ${LOGDIR}/satellite-installer.$(date +%F_%T).log && touch $f
 )
 

--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -59,9 +59,9 @@ RHEL_ISO=$(ls -1t ${ISO_DIR}/rhel*.iso | head -n 1)
 SATELLITE_ISO=$(ls -1t ${ISO_DIR}/satellite*.iso | head -n 1)
 USE_RPM_INSTALL_SCRIPT=no
 
-SATELLITE_INSTALLER_OPTIONS="
+SATELLITE_INSTALLER_OPTIONS=(
 {{- '--foreman-admin-email=%s' % satellite.admin.email|default('root@localhost') }} \
-{{  '--foreman-initial-organization=%s' % satellite.organization if satellite.organization }} \
+{{  "'--foreman-initial-organization=%s'" % satellite.organization if satellite.organization }} \
 {{  '--foreman-initial-location=%s' % satellite.location if satellite.location }} \
 {% if satellite.tls is defined -%} \
 {{    '--certs-country=%s' % satellite.tls.country if satellite.tls.country else 'JP' }} \
@@ -77,7 +77,7 @@ SATELLITE_INSTALLER_OPTIONS="
 {{     '--katello-proxy-username=%s' % proxy.user if proxy.user }} \
 {{     '--katello-proxy-password=%s' % proxy.password if proxy.password }} \
 {% endif -%}
-"
+)
 
 ORG_NAME="{{ satellite.organization|default('Default Organization') }}"
 ORG_LABEL="${ORG_NAME// /_}"


### PR DESCRIPTION
This is a temporal solution for rewriting all the code with Ansible.