### PR TITLE
enhance: [satellite] don't use --by option in hammer command invocations

### DIFF
--- a/autoinstall.d/data/satellite/6/20_setup_organization.sh
+++ b/autoinstall.d/data/satellite/6/20_setup_organization.sh
@@ -49,9 +49,9 @@ base64 -d ${MANIFEST_ZIP_BASE64:?} > ${MANIFEST_ZIP}
 hammer subscription upload --file ${MANIFEST_ZIP}
 
 # List products and repository-sets available from the manifest.
-hammer --csv product list --by name
-hammer --csv repository-set list --product "Red Hat Enterprise Linux Server" --by name
-hammer --csv repository-set list --product "Red Hat Software Collections for RHEL Server" --by name
+hammer --csv product list
+hammer --csv repository-set list --product "Red Hat Enterprise Linux Server"
+hammer --csv repository-set list --product "Red Hat Software Collections for RHEL Server"
 
 # vim:sw=2:ts=2:et:
 {#

--- a/autoinstall.d/data/satellite/6/30_enable_yum_repos.sh
+++ b/autoinstall.d/data/satellite/6/30_enable_yum_repos.sh
@@ -18,7 +18,7 @@ source ${0%/*}/config.sh
 curl --connect-timeout 10 --cacert /etc/rhsm/ca/redhat-uep.pem ${CURL_PROXY_OPT} https://cdn.redhat.com/
 
 # List products and repository-sets (all available repos) by products might be used.
-hammer --csv product list --by name
+hammer --csv product list
 while read line; do test "x$line" = "x" || (eval ${line} || :); done << EOC
 ${LIST_REPOSITORY_SET_BY_PRODUCTS}
 EOC

--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -117,7 +117,7 @@ PRODUCTS="
 
 LIST_REPOSITORY_SET_BY_PRODUCTS="
 {% for p in satellite.products if p.name -%}
-hammer --csv repository list --product '{{ p.name }}' --by name
+hammer --csv repository list --product '{{ p.name }}'
 {% endfor -%}
 "
 


### PR DESCRIPTION
In satellite-6.5, --by option is removed from hammer command.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>