### PR TITLE
enhance: [satellite] provide the way to specify subscription by its contracts

### DIFF
--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -168,15 +168,20 @@ ADD_SUBSCRIPTION_TO_ACTIVATION_KEYS='
 {% for ak in satellite.activation_keys if ak.name and
                                           (ak.subscription is defined and ak.subscription) or
                                           (ak.subscriptions is defined and ak.subscriptions) or
-                                          (ak.subscription_contract is defined and ak.subscription_contract) -%}
+                                          (ak.subscription_contract is defined and ak.subscription_contract) or
+                                          (ak.subscription_contracts is defined and ak.subscription_contracts) -%}
 {%     if ak.subscriptions -%}
 {%         for sub in ak.subscriptions -%}
 sub_id=$(hammer --csv subscription list | sed -nr "s/.+,([^,]+),{{ sub }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
 {%         endfor -%}
 {%     elif ak.subscription -%}
 sub_id=$(hammer --csv subscription list | sed -nr "s/.+,([^,]+),{{ ak.subscription }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
-{%     else -%}
+{%     elif ak.subscription_contract -%}
 sub_id=$(hammer --csv subscription list | sed -nr "s/^[^,]+,([^,]+),.+,{{ ak.subscription_contract }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
+{%     elif ak.subscription_contracts -%}
+{%         for subc in ak.subscription_contracts -%}
+sub_id=$(hammer --csv subscription list | sed -nr "s/^[^,]+,([^,]+),.+,{{ subc }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
+{%         endfor -%}
 {%     endif -%}
 {% endfor -%}
 '


### PR DESCRIPTION
]ADD_SUBSCRIPTION_TO_ACTIVATION_KEYS in config.sh uses a subscription
name as a pattern for extracting a subscription id from the output of
hammer command. The pattern is embedded into an argument for sed command.

However, writing a subscription name as a effective pattern for extracting
in yml is not easy because:

* a subscription name can include comma characters and parenthesis characters like:

  Red Hat Enterprise Linux Server, Standard (Physical or Virtual Nodes)

* csv output of hammer users double quotes for warpping a subscription name like:

    # hammer --csv subscription list
    ID,UUID,Name,Type,Contract,Account,Support,End Date,Quantity,Consumed
    1,xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,"Red Hat Enterprise Linux Server, Premium (...)",...

This change provides the way to specify MULTIPLE contracts for
extracting a subscription ids instead of names.

"rct cat-manifest" command helps to know the available contracts from a manifest
zip file.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>