### PR TITLE
enhance: use python's print as a function in vmbuild

### DIFF
--- a/guest/vmbuild.sh
+++ b/guest/vmbuild.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # see also virt-install(1)
-function genmac () { python -c 'from random import randint as f; print ":".join("%02x" % x for x in (0x52, 0x54, 0x00, f(0x00, 0x7f), f(0x00, 0xff),  f(0x00, 0xff)))'; }
+function genmac () { python -c 'from random import randint as f; print (":".join("%02x" % x for x in (0x52, 0x54, 0x00, f(0x00, 0x7f), f(0x00, 0xff),  f(0x00, 0xff))))'; }
 {% macro net_option(nic) -%}
 {%     if nic.bridge is defined -%}
 bridge={{ nic.bridge }}


### PR DESCRIPTION
In vmbuild.sh script, python command is used for generating a
mac address. However, the script assumes implicitly that the python
command is python2; print is not a function. As the result, the
script doesn't work well on Fedora 31 where python command is
python3.

In python3, print is a function. It takes arguments surrounded by
`(' and `)'.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>