### PR TITLE
enhance: [satellite] use ID instead of UUID when adding a subscription to an activation key

### DIFF
--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -175,15 +175,15 @@ ADD_SUBSCRIPTION_TO_ACTIVATION_KEYS='
                                           (ak.subscription_contracts is defined and ak.subscription_contracts) -%}
 {%     if ak.subscriptions -%}
 {%         for sub in ak.subscriptions -%}
-sub_id=$(hammer --csv subscription list | sed -nr "s/.+,([^,]+),{{ sub }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
+sub_id=$(hammer --csv subscription list | sed -nr "s/^([^,]+),[0-9a-f]+,{{ sub }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
 {%         endfor -%}
 {%     elif ak.subscription -%}
-sub_id=$(hammer --csv subscription list | sed -nr "s/.+,([^,]+),{{ ak.subscription }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
+sub_id=$(hammer --csv subscription list | sed -nr "s/^([^,]+),[0-9a-f]+,{{ ak.subscription }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
 {%     elif ak.subscription_contract -%}
-sub_id=$(hammer --csv subscription list | sed -nr "s/^[^,]+,([^,]+),.+,{{ ak.subscription_contract }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
+sub_id=$(hammer --csv subscription list | sed -nr "s/^([^,]+),[0-9a-f]+,.+,{{ ak.subscription_contract }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
 {%     elif ak.subscription_contracts -%}
 {%         for subc in ak.subscription_contracts -%}
-sub_id=$(hammer --csv subscription list | sed -nr "s/^[^,]+,([^,]+),.+,{{ subc }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
+sub_id=$(hammer --csv subscription list | sed -nr "s/^([^,]+),[0-9a-f]+,.+,{{ subc }},.*/\\1/p"); hammer activation-key add-subscription --name "{{ ak.name }}" --subscription-id ${sub_id} --quantity {{ ak.quantity|default("1") }}
 {%         endfor -%}
 {%     endif -%}
 {% endfor -%}


### PR DESCRIPTION
When adding a subscription to an activation key, config.sh uses
--subscription-id option of "hammer activation-key add-subscription"
command.

Till satellite-6.6, --subscription-id can take either a value of "ID" column
or a value of "UUID" column of the output of "hammer subscription list":

    # hammer --csv subscription list
    ID,UUID,Name,Type,Contract,Account,Support,Start Date,End Date,Quantity,Consumed
    17,59b2d5c03...,Red Hat Ansible Automation Platform for Certified Cloud and Service Providers,...
    8,f7fecdc74f...,Hat Certified Cloud and Service Provider Program Subscription, Full Support,...

Since satellite-6.7, it seems that --subscription-id takes only a
value of "ID" column. Passing a value of "UUID" column,
59b2d5c03... in above example, causes an error.

config.sh of miniascape-templates specified the value of "UUID" column as
the argument of --subscription-id. To avoid the error, this change makes
config.sh specify the value of "ID" column, 17 in above example, instead.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>