### PR TITLE
enhance: [satellite] use hammer command to set up http proxy

### DIFF
--- a/autoinstall.d/data/satellite/6/21_setup_proxy.sh
+++ b/autoinstall.d/data/satellite/6/21_setup_proxy.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+#
+# Setup proxy
+#    Since Satellite 6.7, a http proxy for synchronizing repositories can be
+#    set after running satellite-installer. The options for specifying a
+#    http proxy is deleted from satellite-installer.
+#
+# Author: Masatake YAMATO <yamato@redhat.com>
+# License: MIT
+#
+# References:
+# - Satellite 6.7 Installing Satellite Server from a Connected Network,
+#   3.4.1. Adding a Default HTTP Proxy to Satellite
+#
+set -ex
+ 
+# PROXY_URL, PROXY_PORT
+source ${0%/*}/config.sh
+ 
+if [ -z "${PROXY_URL}" ]; then
+    exit 0
+fi
+ 
+hammer --no-use-defaults http-proxy create --name=myproxy --url ${PROXY_URL}
+hammer --no-use-defaults settings set --name=content_default_http_proxy --value=myproxy
+
+if [ -z "${PROXY_PORT}" ]; then
+    exit 0
+fi
+case "${PROXY_PORT}" in
+    # predefined squid_port_t
+    3128|3401|4827)
+	exit 0
+	;;
+    # predefined http_cache_port_t
+    8080|8118|8123|10010|1000[0-9])
+	exit 0
+	;;
+esac
+semanage port -a -t http_cache_port_t -p tcp ${PROXY_PORT}

--- a/autoinstall.d/data/satellite/6/config.sh
+++ b/autoinstall.d/data/satellite/6/config.sh
@@ -73,13 +73,7 @@ SATELLITE_INSTALLER_OPTIONS="
 {{    '--certs-org=%s' % satellite.tls.org if satellite.tls.org }} \
 {{    '--certs-org-unit=%s' % satellite.tls.unit if satellite.tls.unit }} \
 {% endif -%} \
-{{ satellite.installer_extra_options|default('') }} \
-{% if proxy and proxy.fqdn -%} \
-{{     '--katello-proxy-url=http://%s' % proxy.fqdn }} \
---katello-proxy-port={{ proxy.port|default('8080') }} \
-{{     '--katello-proxy-username=%s' % proxy.user if proxy.user }} \
-{{     '--katello-proxy-password=%s' % proxy.password if proxy.password }} \
-{% endif -%}
+{{ satellite.installer_extra_options|default('') }}
 "
 
 ORG_NAME="{{ satellite.organization|default('Default Organization') }}"
@@ -92,6 +86,7 @@ test -f ${ORG_ID_FILE:?} && HAMMER_ORG_ID_OPT="--organization-id $(cat ${ORG_ID_
 
 CURL_PROXY_OPT=""
 {% if proxy and proxy.fqdn -%}
+PROXY_PORT={{ proxy.port|default('8080') }}
 PROXY_URL={{ "http://%s:%s" % (proxy.fqdn, proxy.port|default('8080')) }}
 CURL_PROXY_OPT="${CURL_PROXY_OPT} --proxy ${PROXY_URL} {{ ' --proxy-user %s:%s' % (proxy.user, proxy.password) if proxy.user and proxy.password }}"
 tweak_selinux_policy () {


### PR DESCRIPTION
In satellite-6.7, options for setting up a http proxy are removed
from satellite-installer. Instead, 'hammer http-proxy create' command
can be used for setting up a http proxy.

This change introduces 21_setup_proxy.sh for running
'hammer http-proxy create'.

References:
- Satellite 6.7 Installing Satellite Server from a Connected Network,
  3.4.1. Adding a Default HTTP Proxy to Satellite

Signed-off-by: Masatake YAMATO <yamato@redhat.com>