### PR TITLE
enhance: create /boot/efi when 'uefi' is true

### DIFF
--- a/autoinstall.d/snippets/ks/main.partitions
+++ b/autoinstall.d/snippets/ks/main.partitions
@@ -21,6 +21,9 @@ autopart{% endif %}
 -#}
 zerombr
 clearpart --all --initlabel
+{%- if uefi is defined and uefi %}
+reqpart
+{%- endif %}
 {% if partition is defined and partition -%}
 {{     partition -}}
 {% else -%}


### PR DESCRIPTION
UEFI machine needs /boot/efi directory.
reqpart directive creates the directory when installing OS.
See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-syntax#sect-kickstart-commands
about the reqpart directive.

With this change, miniascape inserts the reqpart directive
before a definition of partions in kickstart files when 'uefi'
is true.

Eaxmple of kickstart emission:
$ jinja2 -D uefi=yes miniascape-templates/autoinstall.d/snippets/ks/main.partitions
zerombr
clearpart --all --initlabel
reqpart
part /boot  --size=500 --fstype ext4
part pv.100 --size=1 --grow
volgroup vg01 pv.100
logvol swap --fstype swap --name=lv01 --vgname=vg01 --size=
logvol /    --fstype  --name=lv02 --vgname=vg01 --size=1 --grow

Signed-off-by: Masatake YAMATO <yamato@redhat.com>