### PR TITLE
change: pass 'en-us' as default keymap to virtinst

### DIFF
--- a/guest/vmbuild.sh
+++ b/guest/vmbuild.sh
@@ -84,7 +84,7 @@ virt-install \
 --vcpus={{ virtinst.vcpus }} \
 {{     ' --cpu %s' % virtinst.cpu if virtinst.cpu }} \
 --graphics {{ virtinst.graphics|default('vnc') -}}
-{{-    ',keymap=%s' % (virtinst.keyboard if virtinst.keyboard else keyboard|default('us')) }} \
+{{-    ',keymap=%s' % (virtinst.keyboard if virtinst.keyboard else keyboard|default('en-us')) }} \
 --os-type={{ virtinst.os_type|default('linux') }} \
 --os-variant={{ virtinst.os_variant }} \
 {%     if use_serial_console and virtinst.os_variant and virtinst.os_variant == 'rhel7' -%}


### PR DESCRIPTION
It seems that a newer virtinst command doesn't accept 'us' as default keymap.

ref. https://bugzilla.redhat.com/show_bug.cgi?id=244787#c13

Signed-off-by: Masatake YAMATO <yamato@redhat.com>