### PR TITLE
change: [rhel8-min] adjust package list as suitable to be used from rhel-8-min-ks.cfg

### DIFF
--- a/autoinstall.d/data/rhel-8_basic_tools_rpms
+++ b/autoinstall.d/data/rhel-8_basic_tools_rpms
@@ -1,4 +1,4 @@
-@Core
+@^minimal-environment
 NetworkManager-config-server
 bash-completion
 bind-utils
@@ -10,7 +10,6 @@ lftp
 make
 nfs-utils
 nmap-ncat
-pcp
 psmisc
 rsync
 sos

--- a/autoinstall.d/data/rhel-8_uninstalled_rpms
+++ b/autoinstall.d/data/rhel-8_uninstalled_rpms
@@ -1,4 +1,3 @@
--*-firmware
 -NetworkManager-t*
 -NetworkManager-w*
 -Red_Hat_Enterprise_Linux-Release_Notes-*


### PR DESCRIPTION
The package list declared in rhel-8_basic_tools_rpms is too large to
be used from from rhel-8-min-ks.cfg.

This change makes the list a bit smaller.

* Use "@^minimal-environment" ENVIRONMENT instead of "@Core" GROUP.

  This item mya not change the package list; the package set
  of "@^minimal-environment" may be the same as "@Core".

  The installation of RHUI4 may require this change.
  RHUI4 to be installed with rhel-8-min-ks.cfg requires a RHEL8
  with "Minimal installation":

  https://access.redhat.com/documentation/en-us/red_hat_update_infrastructure/4.0_beta/html-single/installing_red_hat_update_infrastructure/index#ref_technical-configuration-required-for-installing-rhui_installing-red-hat-update-infrastructure

  Though the change is for RHUI4, this item may be acceptable in
  the other purpose.

* Don't include pcp package.

  pcp requires pcp-libs.
  pcp-libs requires libavahi-client.
  However, "avahi*" is listed in rhel-8_uninstalled_rpms
  as a package set to be uninstalled. As the result, pcp cannot be
  installed. Removing "avahi*" from the list is one of the way
  to solve the conflict. However, this item remove the pcp package
  because installing pcp is a bit overkill in rhel-8-min-ks.cfg.

* Include firmware related packages.

  kernel-core that is part of @Core requires linux requires linux-firmware.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>