### PR TITLE
enhance: [rhel9-min] new kickstart file for rhel9

### DIFF
--- a/autoinstall.d/rhel-9-min-ks.cfg
+++ b/autoinstall.d/rhel-9-min-ks.cfg
@@ -1,0 +1,10 @@
+{% extends "rhel-8-min-ks.cfg" -%}
+
+{%  block post -%}
+{{    super() }}
+{%    if sshRootLogin is defined and sshRootLogin -%}
+{%        include "snippets/post.ssh_root_login" -%}
+{%    endif %}
+{%- endblock %}
+{# vim:sw=4:ts=4:et:
+#}

--- a/autoinstall.d/snippets/post.ssh_root_login
+++ b/autoinstall.d/snippets/post.ssh_root_login
@@ -1,0 +1,1 @@
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf

--- a/guest/vmbuild.sh
+++ b/guest/vmbuild.sh
@@ -55,6 +55,9 @@ extra_args="{{ 'inst.loglevel=debug inst.text inst.' if virtinst.os_variant and 
    virtinst.os_variant.startswith('rhel7')
 or virtinst.os_variant.startswith('rhel8')
 )}}ks=file:/${kscfg} {{ virtinst.extra_args|default('') }}"
+{%         if virtinst.os_variant and virtinst.os_variant.startswith('rhel8') -%}
+extra_args="$extra_args net.ifnames=0 biosdevname=0"
+{%         endif -%}
 {%         if interfaces|length > 1 -%}
 extra_args="$extra_args{{ ' ksdevice=%s' % ksdevice if ksdevice and not (virtinst and virtinst.os_variant in ('rhel7', 'fedora21')) }}"
 {%         endif -%}

--- a/guest/vmbuild.sh
+++ b/guest/vmbuild.sh
@@ -54,8 +54,9 @@ location_opts="--location={{ virtinst.location }} --initrd-inject=${ks_path}"
 extra_args="{{ 'inst.loglevel=debug inst.text inst.' if virtinst.os_variant and (
    virtinst.os_variant.startswith('rhel7')
 or virtinst.os_variant.startswith('rhel8')
+or virtinst.os_variant.startswith('rhel9')
 )}}ks=file:/${kscfg} {{ virtinst.extra_args|default('') }}"
-{%         if virtinst.os_variant and virtinst.os_variant.startswith('rhel8') -%}
+{%         if virtinst.os_variant and virtinst.os_variant.startswith('rhel8') or virtinst.os_variant.startswith('rhel9') -%}
 extra_args="$extra_args net.ifnames=0 biosdevname=0"
 {%         endif -%}
 {%         if interfaces|length > 1 -%}


### PR DESCRIPTION
    enhance: [rhel9-min] new kickstart file for rhel9
    
    This one is derived from rhel8-min.
    rhel9-min is mostly the same as rhel8-min except for sshRootLogin.
    
    Since rhel9, root login via ssh is not permitted by default.
    However, root login via ssh is convenient for testing.
    Setting sshRootLogin true prepares a configuration file for permitting
    root login via ssh.
    
    Here is a fragmentation of a YAML file setting sshRootLogin true:
    
        guests:
          - hostname: rhel-9-client-1
            name: rhel-9-client-1
    
            # Since RHEL9, sshd doesn't permit root to login by default.
            sshRootLogin: true
    
            interfaces:
              - network: *rhui_network_1
                bootproto: static
                ip: 192.168.125.14
                fqdn: rhel-9-test-client-1.example.co.jp
                gateway: *gateway_1
                netmask: *netmask_1
    
    Signed-off-by: Masatake YAMATO <yamato@redhat.com>
